### PR TITLE
[#73] Coverrals bage switched to develop

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/libproject/libproject.svg?branch=develop)](https://travis-ci.org/libproject/libproject)
 
-[![Coverage Status](https://coveralls.io/repos/libproject/libproject/badge.svg)](https://coveralls.io/r/libproject/libproject)
+[![Coverage Status](https://coveralls.io/repos/libproject/libproject/badge.svg?branch=develop)](https://coveralls.io/r/libproject/libproject?branch=develop)
 
 This is develop repository of LPROJ (at now)
 


### PR DESCRIPTION
closes #73 
Coveralls badge pointed to wrong branch was fixed
